### PR TITLE
Fix void-function incf error

### DIFF
--- a/nav-flash.el
+++ b/nav-flash.el
@@ -196,7 +196,7 @@ this function a no-op."
         (end-of-visual-line)
         (setq end-pos (1+ (point))))))
   (when (eq pos end-pos)
-    (incf end-pos))
+    (cl-incf end-pos))
   (cl-callf or delay nav-flash-delay)
   (cl-callf or face 'nav-flash-face)
   (when (and (numberp delay)


### PR DESCRIPTION
An `incf` macro call was missed in dbb9121. In a session where `cl` hasn't been loaded, the `incf` macro isn't expanded, and calls to `nav-flash-show` result in a `void-function: incf` error.