### PR TITLE
Add :extend to nav-flash-face

### DIFF
--- a/nav-flash.el
+++ b/nav-flash.el
@@ -157,7 +157,7 @@ Setting this to nil or 0 will turn off the indicator."
 
 ;; note nav-flash-face is customizable, but nav-flash-pulse-face is not
 (defface nav-flash-face
-  '((t (:inherit highlight)))
+  '((t (:inherit highlight :extend t)))
   "Face to flash the current line."
   :group 'nav-flash)
 


### PR DESCRIPTION
Emacs 27 introduces a new face attribute, `:extend`, which controls:

> Whether or not this face will be extended beyond end of line and will affect the display of the empty space between the end of line and the edge of the window. The value should be t to display the empty space between end of line and edge of the window using this face, or nil to not use this face for the space between the end of the line and the edge of the window. When Emacs merges several faces for displaying the empty space beyond end of line, only those faces with :extend non-nil will be merged. By default, only a small number of faces, notably, region, have this attribute set. This attribute is different from the others in that when a theme doesn’t specify an explicit value for a face, the value from the original face definition by defface is inherited (see Defining Faces).

([Source](https://www.gnu.org/software/emacs/manual/html_node/elisp/Face-Attributes.html))

This ensures that, whenever this face is applied to text that contains a newline, the highlight will stretch to the right edge of the window, which seems to be the intended effect for this face.

Emacs 26.x and earlier won't complain about this unrecognized attribute.